### PR TITLE
Bump runtime version to 44

### DIFF
--- a/com.github.sdv43.whaler.yml
+++ b/com.github.sdv43.whaler.yml
@@ -1,6 +1,6 @@
 app-id: com.github.sdv43.whaler
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '44'
 sdk: org.gnome.Sdk
 command: com.github.sdv43.whaler
 finish-args:

--- a/com.github.sdv43.whaler.yml
+++ b/com.github.sdv43.whaler.yml
@@ -53,5 +53,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/sdv43/whaler.git
-        tag: 1.2.0
-        commit: 6a72b3cff9df1532c5ecd1260f0e399e8facefd9
+        tag: 1.2.1
+        commit: 133ac20614ed835ebe7bea73d895dc70df71b99e


### PR DESCRIPTION
the `org.gnome.Sdk` version 42 is eol, so I'm bumping it to the latest release, which is 44. It shouldn't be a problem, I tested it and it seems to work just fine.