### PR TITLE
Update runtime to 50 and more

### DIFF
--- a/com.github.sdv43.whaler.yml
+++ b/com.github.sdv43.whaler.yml
@@ -1,69 +1,30 @@
 app-id: com.github.sdv43.whaler
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '50'
 sdk: org.gnome.Sdk
+base: io.elementary.BaseApp
+base-version: circe-25.08
 command: com.github.sdv43.whaler
 finish-args:
-  - '--share=ipc'
-  - '--socket=fallback-x11'
-  - '--socket=wayland'
-  - '--filesystem=/run/docker.sock'
-  - '--filesystem=xdg-run/docker.sock'
-  - '--filesystem=/run/podman/podman.sock'
-  - '--filesystem=xdg-run/podman/podman.sock'
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --filesystem=/run/docker.sock
+  - --filesystem=xdg-run/docker.sock
+  - --filesystem=/run/podman/podman.sock
+  - --filesystem=xdg-run/podman/podman.sock
+cleanup-commands:
+  - rm -rf /app/bin/sassc
+  - rm -rf /app/include
+  - rm -rf /app/lib/girepository-1.0
+  - rm -rf /app/lib/pkgconfig
+  - rm -rf /app/share/gir-1.0
+  - rm -rf /app/share/vala
+  - rm -rf /app/lib/libgee*
+  - rm -rf /app/lib/libgranite-7*
+  - rm -rf /app/lib/libportal*
+  - rm -rf /app/lib/libsass*
 modules:
-  - name: granite
-    buildsystem: meson
-    sources:
-      - type: git
-        url: https://github.com/elementary/granite.git
-        tag: 6.2.0
-  - name: elementary-stylesheet     
-    buildsystem: meson
-    sources:
-      - type: git
-        url: https://github.com/elementary/stylesheet.git
-        tag: 6.1.1
-    modules: 
-      - name: sassc
-        cleanup:
-          - '*'
-        sources: 
-          - type: git
-            url: https://github.com/sass/sassc.git
-            tag: 3.6.2
-          - type: script
-            dest-filename: autogen.sh
-            commands:
-                  - autoreconf -si
-        modules: 
-          - name: sassc
-            cleanup:
-              - '*'
-            sources: 
-              - type: git
-                url: https://github.com/sass/libsass.git
-                tag: 3.6.5
-              - type: script
-                dest-filename: autogen.sh
-                commands:
-                  - autoreconf -si
-  - name: elementary-icons
-    buildsystem: meson
-    config-opts:
-      - '-Dpalettes=false'
-    sources:
-      - type: git
-        url: https://github.com/elementary/icons.git
-        tag: 6.1.0
-    modules:
-      - name: xcursorgen
-        cleanup:
-          - '*'
-        sources:
-          - type: archive
-            url: https://gitlab.freedesktop.org/xorg/app/xcursorgen/-/archive/xcursorgen-1.0.7/xcursorgen-xcursorgen-1.0.7.tar.gz
-            sha256: 7fb30a052b63e3ed02c9e43bd70fe1bf8189f2f3d702ab43b5b0726a2dbafccd
   - name: whaler
     buildsystem: meson
     sources:


### PR DESCRIPTION
- Update the runtime version to 50
- Use the elementary BaseApp to avoid building common modules
- Remove the baseApp-related redundant files and modules
- Other small fixes

**Please don't forget to test before merging.**

**The installed size increased from 45 MB to 53 MB, due to updated icons.**